### PR TITLE
ci: cover macOS CompiledModel, on-device Interpreter coexistence, and delegate engagement

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -54,6 +54,45 @@ jobs:
         working-directory: example/flex_test_host
         run: flutter test -d macos integration_test
 
+      # Builds the example app and runs real CompiledModel inference inside it,
+      # proving the production load path end to end: the podspec ships
+      # libLiteRt.dylib as a resource and the loader resolves it from inside
+      # the .app rather than from the package checkout. Unlike every other job,
+      # the runner has a working GPU here — macOS runners are Apple silicon and
+      # Metal compute needs no display — so this is the one place in CI where
+      # the strict-GPU and GPU-fallback tests execute for real instead of
+      # skipping.
+      - name: Run CompiledModel integration tests (macOS desktop)
+        working-directory: example
+        run: flutter test integration_test/compiled_model_test.dart -d macos --timeout 600s
+
+      - name: Run Interpreter/CompiledModel coexistence tests (macOS desktop)
+        working-directory: example
+        run: flutter test integration_test/interpreter_coexistence_test.dart -d macos --timeout 600s
+
+      # The classic delegates, on the only runner in this workflow with a real
+      # accelerator. Both suites assert hasActiveDelegate, so a delegate that
+      # stops applying and silently retries on CPU fails here instead of
+      # passing on correct-but-CPU numbers.
+      #
+      # Only these two are wired: CoreML does not actually engage on macOS
+      # (hasActiveDelegate is false for every bundled model, so the suite would
+      # only ever prove the CPU fallback path), and the remaining
+      # integration_test files are benchmarks with no assertions, several of
+      # them reading models from absolute paths outside this repo. Both stay
+      # manual on purpose.
+      #
+      # Separate invocations: passing several integration_test files to one
+      # `flutter test` only launches the app for the first.
+      - name: Run classic delegate integration tests (macOS desktop)
+        working-directory: example
+        run: |
+          for t in metal_delegate_test xnnpack_delegate_test; do
+            echo "::group::$t"
+            flutter test "integration_test/$t.dart" -d macos --timeout 600s
+            echo "::endgroup::"
+          done
+
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -119,6 +158,14 @@ jobs:
         working-directory: example
         run: xvfb-run -a flutter test integration_test/compiled_model_test.dart -d linux --timeout 600s
 
+      # Both native runtimes bundled into one app: linux/lib ships
+      # libtensorflowlite_c-linux.so alongside libLiteRt.so, and they export
+      # overlapping TFLite symbols. Host unit tests only ever load one of them
+      # per process, so the collision risk is only visible here.
+      - name: Run Interpreter/CompiledModel coexistence tests (Linux desktop)
+        working-directory: example
+        run: xvfb-run -a flutter test integration_test/interpreter_coexistence_test.dart -d linux --timeout 600s
+
   build-windows:
     runs-on: windows-2022
     steps:
@@ -161,6 +208,14 @@ jobs:
       - name: Run CompiledModel integration tests (Windows desktop)
         working-directory: example
         run: flutter test integration_test/compiled_model_test.dart -d windows --timeout 600s
+
+      # The classic runtime is exercised on Windows only from inside a built
+      # app: windows/CMakeLists.txt bundles libtensorflowlite_c-win.dll next to
+      # libLiteRt.dll, so this is where the two runtimes first share a process
+      # on this platform.
+      - name: Run Interpreter/CompiledModel coexistence tests (Windows desktop)
+        working-directory: example
+        run: flutter test integration_test/interpreter_coexistence_test.dart -d windows --timeout 600s
 
   build-web:
     runs-on: ubuntu-latest
@@ -276,14 +331,17 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Runs real CompiledModel inference. CPU and fallback-factory tests pass.
-      # The bundled x86_64 accelerator registers, while direct combined and
-      # strict-GPU tests skip because emulators have no working OpenCL. Up to
-      # three attempts: Gradle's SDK-component install
+      # Runs real CompiledModel inference plus the classic Interpreter, which
+      # on Android loads a different library entirely (libtensorflowlite_jni.so
+      # from litert:1.4.x, next to libLiteRt.so from the 2.x AAR) and is
+      # otherwise never executed anywhere in CI. CompiledModel CPU and
+      # fallback-factory tests pass. The bundled x86_64 accelerator registers,
+      # while direct combined and strict-GPU tests skip because emulators have
+      # no working OpenCL. Up to three attempts: Gradle's SDK-component install
       # can receive a corrupted NDK archive ("Error on ZipFile unknown
       # archive"), which fails assembleDebug; purging the partial NDK
       # between attempts makes the retry re-download it cleanly.
-      - name: Run CompiledModel integration tests (Android emulator)
+      - name: Run integration tests (Android emulator)
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
@@ -292,9 +350,15 @@ jobs:
           working-directory: example
           # One line on purpose: the action runs each script line as its own
           # sh command, which tears a multi-line loop apart.
+          #
+          # The two suites are separate `flutter test` invocations, not one
+          # multi-file invocation: passing several integration_test files to a
+          # single run only launches the app for the first one and then fails
+          # the rest with "Unable to start the app on the device".
           script: >-
             bash -c 'set +e; rc=1; for attempt in 1 2 3; do
-            flutter test integration_test/compiled_model_test.dart -d emulator-5554 --timeout 600s; rc=$?;
+            flutter test integration_test/compiled_model_test.dart -d emulator-5554 --timeout 600s &&
+            flutter test integration_test/interpreter_coexistence_test.dart -d emulator-5554 --timeout 600s; rc=$?;
             [ "$rc" -eq 0 ] && break;
             echo "::warning::Android integration tests attempt $attempt failed (rc=$rc)";
             [ "$attempt" -lt 3 ] && rm -rf "$ANDROID_HOME"/ndk/* "$ANDROID_HOME"/.temp;
@@ -368,8 +432,8 @@ jobs:
   build-ios:
     runs-on: macos-15
     # Per-test, per-attempt timeouts and retries live in the test step below.
-    # This outer cap only bounds the complete two-test sequence.
-    timeout-minutes: 70
+    # This outer cap only bounds the complete three-test sequence.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -463,3 +527,4 @@ jobs:
 
           run_ios_test integration_test/compiled_model_test.dart || exit $?
           run_ios_test integration_test/interpreter_delegate_fallback_test.dart || exit $?
+          run_ios_test integration_test/interpreter_coexistence_test.dart || exit $?

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -472,7 +472,14 @@ jobs:
         working-directory: example
         run: |
           set +e
-          attempt_timeout=1500
+          # A successful suite takes 2-5 minutes here including the app build,
+          # so 900s leaves roughly 3x headroom while bounding the damage when
+          # the simulator wedges on launch (the connect-forever hang the
+          # recycle logic below exists for). At the previous 1500s a single
+          # hang burned 25 minutes, and three hung first attempts would exceed
+          # this job's 90-minute cap and be killed mid-run; at 900s the worst
+          # case is about an hour.
+          attempt_timeout=900
           max=2
 
           run_ios_test() {

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -71,23 +71,25 @@ jobs:
         run: flutter test integration_test/interpreter_coexistence_test.dart -d macos --timeout 600s
 
       # The classic delegates, on the only runner in this workflow with a real
-      # accelerator. Both suites assert hasActiveDelegate, so a delegate that
-      # stops applying and silently retries on CPU fails here instead of
+      # accelerator. All three suites assert hasActiveDelegate, so a delegate
+      # that stops applying and silently retries on CPU fails here instead of
       # passing on correct-but-CPU numbers.
       #
-      # Only these two are wired: CoreML does not actually engage on macOS
-      # (hasActiveDelegate is false for every bundled model, so the suite would
-      # only ever prove the CPU fallback path), and the remaining
-      # integration_test files are benchmarks with no assertions, several of
-      # them reading models from absolute paths outside this repo. Both stay
-      # manual on purpose.
+      # CoreML is included because its inference test requests AllDevices.
+      # The default CoreMlDelegate() targets the Neural Engine only and does
+      # not apply on a Mac (or a simulator), so a suite built on the default
+      # options would cover nothing but the CPU fallback.
+      #
+      # The remaining integration_test files stay manual on purpose: they are
+      # benchmarks with no assertions, several reading models from absolute
+      # paths outside this repo.
       #
       # Separate invocations: passing several integration_test files to one
       # `flutter test` only launches the app for the first.
       - name: Run classic delegate integration tests (macOS desktop)
         working-directory: example
         run: |
-          for t in metal_delegate_test xnnpack_delegate_test; do
+          for t in metal_delegate_test xnnpack_delegate_test coreml_delegate_test; do
             echo "::group::$t"
             flutter test "integration_test/$t.dart" -d macos --timeout 600s
             echo "::endgroup::"

--- a/example/integration_test/compiled_model_test.dart
+++ b/example/integration_test/compiled_model_test.dart
@@ -37,24 +37,46 @@ void main() {
   });
 
   group('CompiledModel (LiteRT Next)', () {
-    testWidgets('loads the runtime from the app bundle on Linux/Windows', (
+    testWidgets('loads the runtime from the app bundle on desktop', (
       tester,
     ) async {
-      if (!(Platform.isLinux || Platform.isWindows)) {
-        markTestSkipped('Bundle-origin check is for desktop CMake bundling.');
+      if (!(Platform.isMacOS || Platform.isLinux || Platform.isWindows)) {
+        markTestSkipped('Bundle-origin check is for desktop bundling.');
         return;
       }
       // Force the lazy loader, then assert the library it actually dlopen'd
-      // came from next to the executable (where CMake bundled_libraries puts
-      // it for end users), and not from the loader's package-checkout
-      // fallback, which exists in CI/dev environments but not in shipped
-      // apps. This is what makes a green run prove the bundling worked.
+      // came from inside the built app, and not from the loader's
+      // package-checkout fallback, which exists in CI/dev environments but not
+      // in shipped apps. This is what makes a green run prove the bundling
+      // worked.
       CompiledModel.fromBuffer(
         modelBytes,
         accelerators: {Accelerator.cpu},
       ).close();
-      final execDir = File(Platform.resolvedExecutable).parent.path;
-      final expectedDir = Platform.isLinux ? '$execDir/lib' : execDir;
+      final execDir = File(Platform.resolvedExecutable).parent;
+
+      if (Platform.isMacOS) {
+        // CocoaPods and SwiftPM both ship libLiteRt.dylib as a *resource*, so
+        // unlike the CMake desktops its directory depends on which resource
+        // layout the toolchain picked (the candidates in delegateBundlePaths).
+        // Assert containment in the .app rather than one fixed path; what must
+        // not happen is resolving to the package checkout outside it.
+        final contentsDir = execDir.parent.resolveSymbolicLinksSync();
+        expect(litertRuntimeDir, isNotNull);
+        expect(
+          litertRuntimeDir,
+          startsWith(contentsDir),
+          reason:
+              'runtime resolved outside the app bundle, so the podspec '
+              'resource bundling did not take effect',
+        );
+        return;
+      }
+
+      // CMake bundled_libraries puts the runtime next to the executable.
+      final expectedDir = Platform.isLinux
+          ? '${execDir.path}/lib'
+          : execDir.path;
       expect(
         litertRuntimeDir,
         Directory(expectedDir).resolveSymbolicLinksSync(),

--- a/example/integration_test/coreml_delegate_test.dart
+++ b/example/integration_test/coreml_delegate_test.dart
@@ -58,6 +58,17 @@ void main() {
       final opts = InterpreterOptions()..addDelegate(delegate);
       final interpreter = Interpreter.fromFile(modelFile, options: opts);
 
+      // Interpreter creation retries on CPU when a delegate cannot be applied,
+      // so correct numbers alone do not prove CoreML ran. This holds only
+      // because the delegate above requests AllDevices: the default
+      // (DevicesWithNeuralEngine) does not apply on a Mac or a simulator, and
+      // would legitimately leave hasActiveDelegate false.
+      expect(
+        interpreter.hasActiveDelegate,
+        isTrue,
+        reason: 'CoreML delegate did not apply; inference fell back to CPU',
+      );
+
       // Model is y = 2*x + 1
       var output = [
         [0.0],

--- a/example/integration_test/interpreter_coexistence_test.dart
+++ b/example/integration_test/interpreter_coexistence_test.dart
@@ -1,0 +1,197 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_litert/native.dart';
+
+/// On-device coverage for the classic [Interpreter], and for both native
+/// runtimes being live in one process at the same time.
+///
+/// The package ships two independent runtimes: classic TFLite
+/// (libtensorflowlite_c on desktop, libtensorflowlite_jni on Android, the
+/// TensorFlowLiteC framework on iOS) and LiteRT Next (libLiteRt). They export
+/// overlapping TFLite symbols, so whichever one is dlopen'd first can end up
+/// satisfying the other's relocations. Host unit tests cannot catch that: they
+/// run on macOS and Linux only, and each suite touches a single runtime per
+/// process. Everything here runs inside a real app process, brings the two
+/// runtimes up in both orders, and asserts each keeps producing its own
+/// correct results afterwards.
+///
+/// simple_model is y = 2*x + 1, so the cross-runtime comparisons are exact
+/// rather than a tolerance on a real network's output. The real-network case
+/// below deliberately asserts structure and finiteness instead of numeric
+/// parity: the two runtimes use different kernel libraries, so a tight
+/// tolerance there would be measuring kernel accuracy, not coexistence.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late Uint8List modelBytes;
+  late Uint8List segModelBytes;
+
+  setUpAll(() async {
+    modelBytes = (await rootBundle.load(
+      'assets/simple_model.tflite',
+    )).buffer.asUint8List();
+    segModelBytes = (await rootBundle.load(
+      'assets/selfie_multiclass.tflite',
+    )).buffer.asUint8List();
+  });
+
+  /// Runs simple_model on [interpreter] through the tensor views, the closest
+  /// analogue to the flat-buffer API CompiledModel exposes.
+  double runInterpreter(Interpreter interpreter, double x) {
+    interpreter.getInputTensor(0).asFloat32View()[0] = x;
+    interpreter.invoke();
+    return interpreter.getOutputTensor(0).asFloat32View()[0];
+  }
+
+  double runCompiledModel(CompiledModel cm, double x) {
+    final input = Float32List(cm.inputByteSizes[0] ~/ 4);
+    input[0] = x;
+    return cm.run([input])[0][0];
+  }
+
+  group('classic Interpreter on device', () {
+    testWidgets('runs and returns correct results', (tester) async {
+      final interpreter = Interpreter.fromBuffer(modelBytes);
+      addTearDown(interpreter.close);
+
+      expect(interpreter.getInputTensors(), isNotEmpty);
+      expect(interpreter.getOutputTensors(), isNotEmpty);
+      expect(runInterpreter(interpreter, 3.0), closeTo(7.0, 1e-3));
+      expect(runInterpreter(interpreter, 0.0), closeTo(1.0, 1e-3));
+      expect(runInterpreter(interpreter, -1.0), closeTo(-1.0, 1e-3));
+    });
+
+    testWidgets('runs a real network from the app bundle', (tester) async {
+      // simple_model is a single op. A real graph exercises far more of the
+      // classic runtime's kernel set, and a large output tensor exercises the
+      // read-back path rather than a single float.
+      final interpreter = Interpreter.fromBuffer(segModelBytes);
+      addTearDown(interpreter.close);
+
+      final input = interpreter.getInputTensor(0).asFloat32View();
+      input.fillRange(0, input.length, 0);
+      interpreter.invoke();
+
+      final output = interpreter.getOutputTensor(0).asFloat32View();
+      expect(output.length, greaterThan(1 << 18));
+      expect(output.every((v) => v.isFinite), isTrue);
+    });
+
+    testWidgets('auto PerformanceConfig yields a working interpreter', (
+      tester,
+    ) async {
+      // Covers the platform default delegate path (Metal on Apple, XNNPack
+      // elsewhere) including the CPU retry when a model cannot be delegated.
+      final (options, delegate) = InterpreterFactory.create(
+        const PerformanceConfig(),
+      );
+      final interpreter = Interpreter.fromBuffer(modelBytes, options: options);
+      addTearDown(() {
+        interpreter.close();
+        options.delete();
+        delegate?.delete();
+      });
+
+      expect(runInterpreter(interpreter, 3.0), closeTo(7.0, 1e-3));
+      expect(interpreter.hasActiveDelegate, isA<bool>());
+    });
+  });
+
+  group('Interpreter and CompiledModel in one process', () {
+    testWidgets('CompiledModel loaded second; both keep working', (
+      tester,
+    ) async {
+      final interpreter = Interpreter.fromBuffer(modelBytes);
+      addTearDown(interpreter.close);
+      expect(runInterpreter(interpreter, 3.0), closeTo(7.0, 1e-3));
+
+      // Bringing the second runtime up must not disturb the first: re-running
+      // the interpreter afterwards is the assertion that matters here.
+      final cm = CompiledModel.fromBuffer(
+        modelBytes,
+        accelerators: {Accelerator.cpu},
+      );
+      addTearDown(cm.close);
+
+      expect(runCompiledModel(cm, 3.0), closeTo(7.0, 1e-3));
+      expect(runInterpreter(interpreter, 5.0), closeTo(11.0, 1e-3));
+    });
+
+    testWidgets('Interpreter loaded second; both keep working', (tester) async {
+      final cm = CompiledModel.fromBuffer(
+        modelBytes,
+        accelerators: {Accelerator.cpu},
+      );
+      addTearDown(cm.close);
+      expect(runCompiledModel(cm, 3.0), closeTo(7.0, 1e-3));
+
+      final interpreter = Interpreter.fromBuffer(modelBytes);
+      addTearDown(interpreter.close);
+
+      expect(runInterpreter(interpreter, 3.0), closeTo(7.0, 1e-3));
+      expect(runCompiledModel(cm, 5.0), closeTo(11.0, 1e-3));
+    });
+
+    testWidgets('interleaved runs stay independent', (tester) async {
+      final interpreter = Interpreter.fromBuffer(modelBytes);
+      final cm = CompiledModel.fromBuffer(
+        modelBytes,
+        accelerators: {Accelerator.cpu},
+      );
+      addTearDown(interpreter.close);
+      addTearDown(cm.close);
+
+      // Alternating keeps both runtimes' tensor arenas hot simultaneously; a
+      // shared-state or symbol-collision problem shows up as one side drifting
+      // rather than as a load-time failure.
+      for (var i = 0; i < 10; i++) {
+        final x = i.toDouble();
+        final expected = 2 * x + 1;
+        expect(runInterpreter(interpreter, x), closeTo(expected, 1e-3));
+        expect(runCompiledModel(cm, x), closeTo(expected, 1e-3));
+      }
+    });
+
+    testWidgets('closing one runtime leaves the other usable', (tester) async {
+      final interpreter = Interpreter.fromBuffer(modelBytes);
+      final cm = CompiledModel.fromBuffer(
+        modelBytes,
+        accelerators: {Accelerator.cpu},
+      );
+      addTearDown(interpreter.close);
+
+      expect(runCompiledModel(cm, 3.0), closeTo(7.0, 1e-3));
+      cm.close();
+      expect(runInterpreter(interpreter, 3.0), closeTo(7.0, 1e-3));
+    });
+
+    testWidgets('both runtimes run a real network side by side', (
+      tester,
+    ) async {
+      final interpreter = Interpreter.fromBuffer(segModelBytes);
+      final cm = CompiledModel.fromBuffer(
+        segModelBytes,
+        accelerators: {Accelerator.cpu},
+      );
+      addTearDown(interpreter.close);
+      addTearDown(cm.close);
+
+      final input = interpreter.getInputTensor(0).asFloat32View();
+      input.fillRange(0, input.length, 0);
+      interpreter.invoke();
+      final interpreterOut = interpreter.getOutputTensor(0).asFloat32View();
+
+      final cmOut = cm.run([Float32List(cm.inputByteSizes[0] ~/ 4)])[0];
+
+      // Structural agreement only: both runtimes must see the same graph and
+      // produce usable numbers. See the file comment for why this is not a
+      // tolerance check.
+      expect(cmOut, hasLength(interpreterOut.length));
+      expect(interpreterOut.every((v) => v.isFinite), isTrue);
+      expect(cmOut.every((v) => v.isFinite), isTrue);
+    });
+  });
+}

--- a/example/integration_test/metal_delegate_test.dart
+++ b/example/integration_test/metal_delegate_test.dart
@@ -57,6 +57,16 @@ void main() {
       final opts = InterpreterOptions()..addDelegate(delegate);
       final interpreter = Interpreter.fromFile(modelFile, options: opts);
 
+      // Interpreter creation retries on CPU when a delegate cannot be applied,
+      // so correct numbers alone do not prove Metal ran. Without this the whole
+      // suite stays green while the GPU silently degrades to CPU, which is the
+      // regression this file exists to catch.
+      expect(
+        interpreter.hasActiveDelegate,
+        isTrue,
+        reason: 'Metal delegate did not apply; inference fell back to CPU',
+      );
+
       // Model is y = 2*x + 1
       // f(3) = 7, f(0) = 1, f(-1) = -1
       var output = [

--- a/example/integration_test/xnnpack_delegate_test.dart
+++ b/example/integration_test/xnnpack_delegate_test.dart
@@ -47,6 +47,14 @@ void main() {
       final opts = InterpreterOptions()..addDelegate(delegate);
       final interpreter = Interpreter.fromFile(modelFile, options: opts);
 
+      // Interpreter creation retries on CPU when a delegate cannot be applied,
+      // so correct numbers alone do not prove XNNPack ran.
+      expect(
+        interpreter.hasActiveDelegate,
+        isTrue,
+        reason: 'XNNPack delegate did not apply; inference fell back to CPU',
+      );
+
       // Model is y = 2*x + 1
       // f(3) = 7, f(0) = 1, f(-1) = -1
       var output = [


### PR DESCRIPTION
## What

Three gaps in CI, all verified on real runners rather than inferred.

**1. macOS never ran the CompiledModel suite.** Linux, Windows, Android and iOS all did. macOS ran only the Flex host, so the podspec resource-bundling load path was never exercised end to end. The bundle-origin assertion is generalized to match how macOS actually ships the runtime: `libLiteRt.dylib` is a CocoaPods/SwiftPM *resource*, so it lands in a resource bundle rather than next to the executable, and the check is containment in the `.app` instead of one fixed directory.

macOS runners turn out to have a working GPU (Apple silicon, Metal compute needs no display). This is now the one job in the workflow where the strict-GPU and GPU-fallback tests execute for real instead of skipping. Verified zero skips in the run log, not just a green check.

**2. No on-device coverage of the classic `Interpreter`, and none at all of the two runtimes together.** The package ships two native runtimes exporting overlapping TFLite symbols (`libtensorflowlite_jni.so` from litert 1.4.x alongside `libLiteRt.so` from the 2.x AAR on Android; two DLLs on Windows). Host unit tests only ever load one per process, and Android had no classic Interpreter coverage anywhere in CI.

Adds `interpreter_coexistence_test.dart`, wired into all five native platforms: each load order, interleaved inference, and close-one-keep-the-other. All 8 tests pass on macOS, Linux, Windows, Android and iOS.

**3. Delegate suites could not catch a silent CPU fallback.** `Interpreter._create` retries on CPU when a delegate cannot be applied, so asserting output values alone kept the Metal, XNNPack and CoreML suites green through exactly the regression they exist to catch. Adds `hasActiveDelegate` assertions to all three and wires them onto macOS.

CoreML needed care: the default `CoreMlDelegate()` targets the Neural Engine only and does not apply on a Mac or a simulator. The suite's inference test already requested `AllDevices` for that reason, so the assertion holds there. Confirmed working on a hosted runner under virtualization.

Also tightens the iOS per-attempt watchdog from 1500s to 900s. A successful suite takes 2-5 minutes, so a hang previously burned 25 minutes; with three suites, three hung first attempts would have exceeded the job's cap and been killed mid-run.

## Coverage delta

| | before | after |
|---|---|---|
| macOS CompiledModel end to end | none | covered, real Metal, zero skips |
| Classic Interpreter on Android | none anywhere | 8 tests on emulator |
| Both runtimes in one process | untested | all 5 native platforms |
| Delegates proven to engage | none | Metal, XNNPack, CoreML |
| Real GPU in CI | none | macOS job |

## Deliberately unchanged

The remaining `example/integration_test` files stay manual. They are benchmarks with no `expect()` calls, several reading models from absolute paths outside this repo, so they cannot run on a runner and would assert nothing if they did.

## Verification

Both prior pushes ran the full workflow green on all 7 jobs. The macOS GPU result and the Android coexistence result were confirmed by reading the job logs, since a skip would otherwise have passed silently.